### PR TITLE
fix: revert inline answer parsing in `Attempt` schema

### DIFF
--- a/src/arc_agi_benchmarking/schemas.py
+++ b/src/arc_agi_benchmarking/schemas.py
@@ -141,29 +141,6 @@ class Attempt(BaseModel):
     answer: Union[str, List[List[int]]]
     metadata: AttemptMetadata
     correct: Optional[bool] = None
-    
-    @model_validator(mode='before')
-    @classmethod
-    def validate(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """Ensure answer is properly serialized"""
-        if not isinstance(values, dict):
-            return values
-            
-        answer = values.get('answer')
-        if isinstance(answer, list):
-            # Convert nested list to string representation
-            values['answer'] = json.dumps(answer)
-
-        if isinstance(values['answer'], str):
-            values['answer'] = json.loads(values['answer'])
-            
-        return values
-    
-    model_config = {
-        'json_encoders': {
-            datetime: lambda v: v.isoformat()
-        }
-    }
 
 class TestPairAttempts(BaseModel):
     attempts: List[Optional[Attempt]]


### PR DESCRIPTION
**fix: revert inline answer parsing in `Attempt` schema**

* Removed `@model_validator` that auto-parsed `answer` field from stringified JSON.
* Allowed `answer` to remain a raw string or list; backparser now handles interpretation externally.
* Deleted `model_config` related to JSON encoding, no longer necessary.
* Schema now aligns with updated flow where parsing is deferred to main logic.
