### PR TITLE
Remove folder for save

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python cli/run_all.py \
 *   `--task_list_file`: Path to the `.txt` file containing task IDs (one per line). (Default: `data/task_lists/public_evaluation_v1.txt`)
 *   `--model_configs`: Comma-separated list of model configuration names from `models.yml`. (Default: `gpt-4o-2024-11-20`)
 *   `--data_dir`: Data set directory. (Default: `data/arc-agi/data/evaluation`)
-*   `--submissions-root`: Root folder to save submissions. Subfolders per config will be created. (Default: `submissions`)
+*   `--submissions-root`: Root folder to save submissions. (Default: `submissions`)
 *   `--overwrite_submission`: Overwrite existing submissions. (Default: `False`)
 *   `--print_submission`: Enable `ARCTester` to log final submission content (at INFO level). (Default: `False`)
 *   `--num_attempts`: Number of attempts by `ARCTester` for each prediction. (Default: `2`)

--- a/cli/run_all.py
+++ b/cli/run_all.py
@@ -116,7 +116,6 @@ async def run_single_test_wrapper(config_name: str, task_id: str, limiter: Async
                                   overwrite_submission: bool, print_submission: bool,
                                   num_attempts: int, retry_attempts: int) -> bool: # removed print_logs
     logger.info(f"[Orchestrator] Queuing task: {task_id}, config: {config_name}")
-    save_submission_dir_for_config = os.path.join(submissions_root, config_name)
 
     # Apply tenacity retry decorator directly to the synchronous function
     # The logger passed to before_sleep_log is the module-level logger of cli.run_all
@@ -130,7 +129,7 @@ async def run_single_test_wrapper(config_name: str, task_id: str, limiter: Async
         logger.debug(f"[Thread-{task_id}-{config_name}] Spawning ARCTester (Executing attempt)...")
         arc_solver = ARCTester(
             config=config_name,
-            save_submission_dir=save_submission_dir_for_config,
+            save_submission_dir=submissions_root,
             overwrite_submission=overwrite_submission,
             print_submission=print_submission, # This ARCTester arg controls if it logs submission content
             num_attempts=num_attempts,


### PR DESCRIPTION
Previously the run all script would create a config sub folder within `submission_root`

Switching this to be more explicit and have results saved directly at submission_root without appending anything