### PR TITLE
Openrouter

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
 import json
-from arc_agi_benchmarking.adapters import ProviderAdapter, AnthropicAdapter, OpenAIAdapter, DeepseekAdapter, GeminiAdapter, HuggingFaceFireworksAdapter, FireworksAdapter, GrokAdapter
+from arc_agi_benchmarking.adapters import ProviderAdapter, AnthropicAdapter, OpenAIAdapter, DeepseekAdapter, GeminiAdapter, HuggingFaceFireworksAdapter, FireworksAdapter, GrokAdapter, OpenRouterAdapter
 from dotenv import load_dotenv
 import arc_agi_benchmarking.utils as utils
 from arc_agi_benchmarking.utils.metrics import timeit, set_metrics_enabled
@@ -49,6 +49,8 @@ class ARCTester:
             return FireworksAdapter(self.config)
         elif provider_name == "grok":
             return GrokAdapter(self.config)
+        elif provider_name == "openrouter":
+            return OpenRouterAdapter(self.config)
         else:
             raise ValueError(f"Unsupported provider: {provider_name}")
         

--- a/provider_config.yml
+++ b/provider_config.yml
@@ -29,5 +29,9 @@ grok:
   rate: 400     # 400 requests
   period: 60    # per 60 seconds
 
+openrouter:
+  rate: 400     # 400 requests
+  period: 60    # per 60 seconds
+
 # Add other provider keys (matching models.yml 'provider' field) and their limits as needed.
 # Ensure these provider keys exactly match what's in your models.yml for each model config. 

--- a/src/arc_agi_benchmarking/adapters/__init__.py
+++ b/src/arc_agi_benchmarking/adapters/__init__.py
@@ -8,3 +8,4 @@ from .gemini import GeminiAdapter
 from .hugging_face_fireworks import HuggingFaceFireworksAdapter
 from .fireworks import FireworksAdapter
 from .grok import GrokAdapter
+from .openrouter import OpenRouterAdapter

--- a/src/arc_agi_benchmarking/adapters/openrouter.py
+++ b/src/arc_agi_benchmarking/adapters/openrouter.py
@@ -91,7 +91,6 @@ class OpenRouterAdapter(OpenAIBaseAdapter):
             metadata=metadata,
             answer=self._get_content(response) # Inherited
         )
-
         return attempt
 
     def extract_json_from_response(self, input_response: str) -> list[list[int]] | None:

--- a/src/arc_agi_benchmarking/adapters/openrouter.py
+++ b/src/arc_agi_benchmarking/adapters/openrouter.py
@@ -1,0 +1,141 @@
+from .provider import ProviderAdapter
+import os
+from dotenv import load_dotenv
+import json
+from openai import OpenAI
+from datetime import datetime, timezone
+from arc_agi_benchmarking.schemas import APIType, AttemptMetadata, Choice, Message, Usage, Cost, CompletionTokensDetails, Attempt
+import logging
+from typing import Optional, Any, List, Dict
+import re
+
+# Import the base class
+from .openai_base import OpenAIBaseAdapter
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+class OpenRouterAdapter(OpenAIBaseAdapter):
+    """Adapter specific to OpenRouter API endpoints and response structures."""
+
+    def init_client(self):
+        """
+        Initialize the OpenAI client configured for OpenRouter API.
+        """
+        api_key = os.environ.get("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY not found in environment variables")
+        
+        client = OpenAI(api_key=api_key, base_url="https://openrouter.ai/api/v1")
+        return client
+
+    def make_prediction(self, prompt: str, task_id: Optional[str] = None, test_id: Optional[str] = None, pair_index: int = None) -> Attempt:
+        """
+        Make a prediction using an OpenRouter model.
+        Relies on OpenAIBaseAdapter for API calls and standard parsing.
+        Specific reasoning token handling might require overriding _get_usage later.
+        """
+        start_time = datetime.now(timezone.utc)
+        
+        # Use the inherited call_ai_model
+        # Assumes OpenRouter uses CHAT_COMPLETIONS or RESPONSES API type defined in config
+        response = self._call_ai_model(prompt)
+        
+        end_time = datetime.now(timezone.utc)
+
+        # Centralised cost calculation (includes sanity-check & calls _get_usage internally)
+        cost = self._calculate_cost(response)
+        
+        # Retrieve usage *after* cost calculation, as cost calc might infer/update reasoning tokens
+        usage = self._get_usage(response)
+        
+        prompt_cost = usage.prompt_tokens * self.model_config.pricing.input / 1_000_000
+        completion_cost = usage.completion_tokens * self.model_config.pricing.output / 1_000_000
+
+        # Convert input messages to choices
+        input_choices = [
+            Choice(
+                index=0,
+                message=Message(role="user", content=prompt)
+            )
+        ]
+
+        # Convert OpenRouter response (assumed OpenAI-compatible) using inherited helpers
+        response_choices = [
+            Choice(
+                index=1,
+                message=Message(
+                    role=self._get_role(response),       # Inherited
+                    content=self._get_content(response)  # Inherited
+                )
+            )
+        ]
+
+        all_choices = input_choices + response_choices
+
+        metadata = AttemptMetadata(
+            model=self.model_config.model_name,
+            provider=self.model_config.provider,
+            start_timestamp=start_time,
+            end_timestamp=end_time,
+            choices=all_choices,
+            kwargs=self.model_config.kwargs,
+            usage=usage,
+            cost=cost,
+            task_id=task_id,
+            pair_index=pair_index,
+            test_id=test_id
+        )
+
+        attempt = Attempt(
+            metadata=metadata,
+            answer=self._get_content(response) # Inherited
+        )
+
+        return attempt
+
+    def extract_json_from_response(self, input_response: str) -> list[list[int]] | None:
+        """Placeholder for OpenRouter-specific JSON extraction. Assumes standard OpenAI format for now."""
+
+        prompt = f"""
+You are a helpful assistant. Extract only the JSON of the test output from the following response. 
+Do not include any explanation or additional text; only return valid JSON.
+
+Response:
+{input_response}
+
+The JSON should be in this format:
+{{
+"response": [
+    [1, 2, 3],
+    [4, 5, 6]
+]
+}}
+"""
+        try:
+            # Use inherited chat_completion or call_ai_model
+            completion = self._chat_completion(
+                messages=[{"role": "user", "content": prompt}],
+            )
+            assistant_content = self._get_content(completion) # Inherited
+        except Exception as e:
+            print(f"Error during AI-based JSON extraction via OpenRouter: {e}")
+            assistant_content = input_response
+
+        # Parsing logic adapted from Deepseek/Fireworks
+        assistant_content = assistant_content.strip()
+        if assistant_content.startswith("```json"):
+            assistant_content = "\n".join(assistant_content.split("\n")[1:])
+        if assistant_content.endswith("```"):
+            assistant_content = "\n".join(assistant_content.split("\n")[:-1])
+        assistant_content = assistant_content.strip()
+
+        try:
+            json_entities = json.loads(assistant_content)
+            potential_list = json_entities.get("response")
+            if isinstance(potential_list, list) and all(isinstance(item, list) for item in potential_list):
+                 if all(isinstance(num, int) for sublist in potential_list for num in sublist):
+                     return potential_list
+            return None
+        except (json.JSONDecodeError, AttributeError):
+            return None

--- a/src/arc_agi_benchmarking/models.yml
+++ b/src/arc_agi_benchmarking/models.yml
@@ -267,6 +267,21 @@ models:
 #### Anthropic ####
 ###################
 
+  - name: "claude-4-sonnet-20250522-thinking-8k-bedrock"
+    model_name: "anthropic/claude-sonnet-4"
+    provider: "openrouter"
+    max_tokens: 32000
+    extra_body:
+      provider:
+        only:
+          - "amazon-bedrock"
+      reasoning:
+        "max_tokens": 8000
+    pricing:
+      date: "2025-05-23"
+      input: 3.00
+      output: 15.00 
+
   - name: "claude-3-7-sonnet-20250219"
     model_name: "claude-3-7-sonnet-20250219"
     provider: "anthropic"

--- a/src/arc_agi_benchmarking/tests/test_openai_providers.py
+++ b/src/arc_agi_benchmarking/tests/test_openai_providers.py
@@ -284,7 +284,8 @@ class TestOpenAIBaseProviderLogic:
         # Patch the methods on the *specific class* being tested
         with patch.object(adapter_class, '_call_ai_model') as mock_call_ai, \
              patch.object(adapter_class, '_get_content', return_value='[[1]]') as mock_get_content, \
-             patch.object(adapter_class, '_get_role', return_value="assistant") as mock_get_role:
+             patch.object(adapter_class, '_get_role', return_value="assistant") as mock_get_role, \
+             patch.object(adapter_class, '_get_reasoning_summary', return_value="Reasoning summary") as mock_get_reasoning_summary:
 
             mock_call_ai.return_value = mock_response_case_a_no_reasoning # Use the Case A fixture
             

--- a/src/arc_agi_benchmarking/tests/test_openai_providers.py
+++ b/src/arc_agi_benchmarking/tests/test_openai_providers.py
@@ -8,6 +8,7 @@ from arc_agi_benchmarking.adapters.open_ai import OpenAIAdapter
 from arc_agi_benchmarking.adapters.grok import GrokAdapter
 from arc_agi_benchmarking.adapters.deepseek import DeepseekAdapter
 from arc_agi_benchmarking.adapters.fireworks import FireworksAdapter
+from arc_agi_benchmarking.adapters.openrouter import OpenRouterAdapter
 # Import all adapters to ensure they are available for discovery
 import arc_agi_benchmarking.adapters 
 


### PR DESCRIPTION
Adding open router as a provider. 

Provider and reasoning tokens can optionally be specified in the config per the docs

https://openrouter.ai/docs/features/provider-routing

Example config:

```
  - name: "claude-4-sonnet-20250522-thinking-8k-bedrock"
    model_name: "anthropic/claude-sonnet-4"
    provider: "openrouter"
    max_tokens: 32000
    extra_body:
      provider:
        only:
          - "amazon-bedrock"
      reasoning:
        "max_tokens": 8000
    pricing:
      date: "2025-05-23"
      input: 3.00
      output: 15.00 
```